### PR TITLE
Domain events draft

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -11,19 +11,13 @@ import (
 func main() {
 	now := time.Now().Format(time.StampMilli)
 	fmt.Println(now, "main program started...")
-	bus := &infra.Bus{}
+	bus := infra.NewBus()
 
 	cmd1 := app.Cmd1{}
-	cmd2 := app.Cmd2{}
 
 	err := bus.Handle(cmd1)
 	if err != nil {
 		fmt.Printf("error from cmd1: %s\n", err)
-	}
-
-	err = bus.Handle(cmd2)
-	if err != nil {
-		fmt.Printf("error from cmd2: %s\n", err)
 	}
 
 	fmt.Println()

--- a/internal/app/use_case1.go
+++ b/internal/app/use_case1.go
@@ -1,9 +1,16 @@
 package app
 
 import (
+	"concurrent-bus/internal/domain"
 	"fmt"
 	"time"
 )
+
+var counter int
+
+func init() {
+	counter = 3
+}
 
 type Cmd1 struct {
 	// ... fields
@@ -13,12 +20,25 @@ type Hndlr1 struct {
 	// ... dependencies
 }
 
-func (h *Hndlr1) Handle(cmd Cmd1) error {
-	// memic the handling period using sleep
-	time.Sleep(time.Second)
-
+func (h *Hndlr1) Handle(cmd Cmd1, domainBus chan<- interface{}) error {
+	counter--
 	now := time.Now().Format(time.StampMilli)
 	fmt.Println(now, "Use-Case 1, handling command normally...")
+
+	fmt.Println("counter is ", counter)
+
+	if counter > 0 {
+		mutatedAgg1, err := domain.MutateAggregate1("foo", 5, domainBus)
+		if err != nil {
+			return err
+		}
+
+		// do something with the aggregate
+		// memic the handling period using sleep
+		fmt.Println(mutatedAgg1)
+	}
+
+	time.Sleep(time.Second)
 
 	return nil
 }

--- a/internal/app/use_case1.go
+++ b/internal/app/use_case1.go
@@ -9,7 +9,7 @@ import (
 var counter int
 
 func init() {
-	counter = 3
+	counter = 2
 }
 
 type Cmd1 struct {
@@ -21,11 +21,8 @@ type Hndlr1 struct {
 }
 
 func (h *Hndlr1) Handle(cmd Cmd1, domainBus chan<- interface{}) error {
-	counter--
 	now := time.Now().Format(time.StampMilli)
 	fmt.Println(now, "Use-Case 1, handling command normally...")
-
-	fmt.Println("counter is ", counter)
 
 	if counter > 0 {
 		mutatedAgg1, err := domain.MutateAggregate1("foo", 5, domainBus)
@@ -35,9 +32,11 @@ func (h *Hndlr1) Handle(cmd Cmd1, domainBus chan<- interface{}) error {
 
 		// do something with the aggregate
 		// memic the handling period using sleep
-		fmt.Println(mutatedAgg1)
+		fmt.Printf("domain event emittid from aggregate %v, while counter is %d", mutatedAgg1, counter)
+		fmt.Println()
 	}
 
+	counter--
 	time.Sleep(time.Second)
 
 	return nil

--- a/internal/domain/aggregate1.go
+++ b/internal/domain/aggregate1.go
@@ -1,0 +1,17 @@
+package domain
+
+type Aggregate1 struct {
+	f1 string
+	f2 int
+}
+
+func MutateAggregate1(f1 string, f2 int, domainBus chan<- interface{}) (*Aggregate1, error) {
+	a := &Aggregate1{f1, f2}
+
+	domainBus <- Event1{f1}
+	return a, nil
+}
+
+type Event1 struct {
+	f1 string
+}

--- a/internal/infra/bus.go
+++ b/internal/infra/bus.go
@@ -3,26 +3,86 @@ package infra
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	"concurrent-bus/internal/app"
 )
 
-type Bus struct {
+type bus struct {
+	// domain bus to transmit domain events
+	domainBus chan interface{}
+	errChan   chan error
+
+	eventCmds []interface{}
+
 	hndlr1 app.Hndlr1
 	hndlr2 app.Hndlr2
 }
 
-// typical approach
-func (b *Bus) Handle(cmd interface{}) error {
+func NewBus() bus {
+	domainBus := make(chan interface{})
+	errChan := make(chan error)
+
+	return bus{
+		domainBus,
+		errChan,
+		[]interface{}{},
+		app.Hndlr1{},
+		app.Hndlr2{},
+	}
+}
+
+func (b *bus) Handle(cmd interface{}) error {
+	go b.handle(cmd)
+
+	for {
+		select {
+		case err := <-b.errChan:
+			if err != nil {
+				return err
+			}
+			return b.handleDomainEvents()
+		case domainEvent := <-b.domainBus:
+			b.registerEventAsCommand(domainEvent)
+		}
+	}
+}
+
+func (b *bus) handleDomainEvents() error {
+	var wg sync.WaitGroup
+	wg.Add(len(b.eventCmds))
+	for _, cmd := range b.eventCmds {
+		go func(c interface{}) {
+			defer wg.Done()
+			b.Handle(c)
+		}(cmd)
+	}
+	wg.Wait()
+	return nil
+}
+
+func (b *bus) registerEventAsCommand(domainEvent interface{}) {
+	eventType := getType(domainEvent)
+	fmt.Println("registering event with type ", eventType)
+
+	b.eventCmds = append(b.eventCmds, app.Cmd2{})
+	b.eventCmds = append(b.eventCmds, app.Cmd2{})
+	b.eventCmds = append(b.eventCmds, app.Cmd2{})
+	// b.eventCmds = append(b.eventCmds, app.Cmd1{})
+}
+
+func (b *bus) handle(cmd interface{}) {
 	cmdType := getType(cmd)
 	switch cmdType {
 	case "Cmd1":
-		return b.hndlr1.Handle(cmd.(app.Cmd1))
+		b.errChan <- b.hndlr1.Handle(cmd.(app.Cmd1), b.domainBus)
+		return
 	case "Cmd2":
-		return b.hndlr2.Handle(cmd.(app.Cmd2))
+		b.errChan <- b.hndlr2.Handle(cmd.(app.Cmd2))
+		return
 	}
 
-	return fmt.Errorf("unable to find handler for cmd %s", cmdType)
+	b.errChan <- fmt.Errorf("unable to find handler for cmd %s", cmdType)
 }
 
 func getType(v interface{}) string {

--- a/internal/infra/bus.go
+++ b/internal/infra/bus.go
@@ -76,6 +76,10 @@ func (b *bus) handleDomainEvents() error {
 }
 
 func (b *bus) registerEventAsCommand(domainEvent interface{}) {
+	// each domain event can become one or more commands
+	// we register them in memory to invoke them later
+	// whenever the main DB transaction finished successfully
+	
 	eventType := b.getType(domainEvent)
 	fmt.Println("registering event with type ", eventType)
 


### PR DESCRIPTION
Introducing a smartter concurrent bus:

- it passes the domain bus channel to receive all domain events through it
- it has the error channel that receives the final result of the command handler
- whenever there is something written in the error channel, this indicates the end of the command life cycle
- in case the error is not a null value, it means the command handling is failed, and we won't handle domain events
- if there was no error, this indicates that the transaction was committed successfully, so we start handling the domain events
- each domain event will be eventually interepreted and registered as a command (or a set of commands) in memory to be handled later through the same cycle...